### PR TITLE
Add technical reference section with input parameters to README

### DIFF
--- a/Package/CatalogInformation/README.md
+++ b/Package/CatalogInformation/README.md
@@ -31,3 +31,13 @@ When investigating issues related to specific views or debugging automation scri
 
 - **DataMiner version**: Main Release 10.4 or higher
 - **User permissions**: Read access to views in the DataMiner system
+
+## Technical Reference
+
+### Input Parameters
+
+| Parameter | Type | Description | Default / Options |
+| --- | --- | --- | --- |
+| RootView | Text (string) | Name or ID of the root view used as the starting point for hierarchy retrieval. | N/A |
+| RootViewInputType | Multiple choice (string) | Defines how `RootView` is interpreted. | Default: `Name`<br>Options: `Name`, `ID` |
+| RecursionLevel | Number | Maximum depth for subview traversal (`1` = direct subviews, `2` = one level deeper, ...).| Default: `1` |


### PR DESCRIPTION
## 🎯 Why

This update enhances the README by providing a technical reference section that details input parameters, improving clarity for users.

## 🔧 Changes

- Added a new section in the README for technical reference.
- Included a table outlining input parameters, their types, descriptions, and default options.

## 🔗 References

<!-- No relevant issues or tasks to reference. -->

## ✅ Checklist

- [ ] Tested on a DataMiner system (or justified why not)
- [ ] No breaking changes — or clearly flagged below

## ⚠️ Reviewer Notes

<!-- Optional: anything a reviewer should know that isn't obvious from the diff. -->
<!-- e.g. "Requires DM 10.4+", "Tested on staging cluster X", "Breaking change for consumers of Y" -->

